### PR TITLE
avoid return duplicate to discard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Ce projet React (avec TypeScript) est une adaptation d'un jeu de rôle créé par Philippe Harrison, dont les règles sont accessibles dans le PDF Dernière-Nuit.pdf (à la racine du projet)
 
+Vous pouvez voir un build du projet à cet url:
+https://derniere-nuit.onrender.com/
+
 ## Scripts disponibles
 
 Vous pouvez utiliser ce script

--- a/src/game.tsx
+++ b/src/game.tsx
@@ -26,6 +26,10 @@ function Game() {
         return cardToDrop;
     }
 
+    function returnCardToDiscard(card: CardInfos): void {
+        setDiscard(prevDiscard => [card, ...prevDiscard])
+    }
+
     function addPillow(): void {
         setPillowCount(prevCount => prevCount + 1);
     }
@@ -78,7 +82,11 @@ function Game() {
                     }}
                 >
                     {Array.from({ length: pillowCount }).map((_, index) => (
-                        <Pillow key={index} cardReceived={takeFirstCardFromDiscard} />
+                        <Pillow
+                            key={index}
+                            cardReceived={takeFirstCardFromDiscard}
+                            returnCard={returnCardToDiscard}
+                        />
                     ))}
                 </div>
             </div>

--- a/src/pillow.tsx
+++ b/src/pillow.tsx
@@ -8,6 +8,7 @@ import {componentType} from "./Types/cardType.tsx";
 
 interface PillowProps {
     cardReceived: () => CardInfos | null
+    returnCard: (cardInfos: CardInfos) => void
 }
 
 function Pillow(props: PillowProps) {
@@ -22,6 +23,18 @@ function Pillow(props: PillowProps) {
             || card.number === cardNumbers.WHITE;
     }
 
+    function sameCardNumber(topCard: CardInfos, newCard: CardInfos) {
+        return topCard.number === newCard.number
+    }
+
+    function sameCardSuite(topCard: CardInfos, newCard: CardInfos) {
+        return topCard.suite === newCard.suite
+    }
+
+    function validCardChain(topCard: CardInfos, newCard: CardInfos) {
+        return sameCardNumber(topCard, newCard) || sameCardSuite(topCard, newCard);
+    }
+
     function receiveCard() {
         const cardReceived = props.cardReceived();
         if (!cardReceived) return;
@@ -29,7 +42,14 @@ function Pillow(props: PillowProps) {
         if (isFace(cardReceived)) {
             setCards(prevCards => prevCards.slice(2))
         } else {
-            setCards(prevCards => [cardReceived, ...prevCards])
+            if (cards.length === 0) {
+                setCards([cardReceived])
+                return
+            } else if (validCardChain(cards.at(0) as CardInfos, cardReceived)) {
+                setCards(prevCards => [cardReceived, ...prevCards])
+                return
+            } else console.error("Invalid card");
+            props.returnCard(cardReceived);
         }
     }
 


### PR DESCRIPTION
Nouvelle logique de Uno pour déposer une carte sur un oreiller. Utilisation d'un callBack avec prevState pour s'assurer d'avoir la version (et éviter la concurrence)